### PR TITLE
Save models at each epoch (fixes #87)

### DIFF
--- a/src/main/java/at/medunigraz/imi/bst/n2c2/nn/BILSTMC3GClassifier.java
+++ b/src/main/java/at/medunigraz/imi/bst/n2c2/nn/BILSTMC3GClassifier.java
@@ -5,14 +5,12 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -64,16 +62,8 @@ public class BILSTMC3GClassifier extends BaseNNClassifier {
 		fullSetIterator = new NGramIterator();
 
 		try {
-
-			// load a properties file
-			Properties prop = new Properties();
-			InputStream input = new FileInputStream(new File(pathToModel, "BILSTMC3G_MBL_0.properties"));
-
-			prop.load(input);
-			this.truncateLength = Integer.parseInt(prop.getProperty("BILSTMC3G_MBL.truncateLength.0"));
-
 			// read char 3-grams and index
-			FileInputStream fis = new FileInputStream(new File(pathToModel, "characterNGram_3_0"));
+			FileInputStream fis = new FileInputStream(new File(pathToModel, "characterNGram_3"));
 			ObjectInputStream ois = new ObjectInputStream(fis);
 			ArrayList<String> characterNGram_3 = (ArrayList<String>) ois.readObject();
 
@@ -82,7 +72,7 @@ public class BILSTMC3GClassifier extends BaseNNClassifier {
 			this.vectorSize = ((NGramIterator)fullSetIterator).vectorSize;
 
 			// read char 3-grams index
-			fis = new FileInputStream(new File(pathToModel, "char3GramToIdxMap_0"));
+			fis = new FileInputStream(new File(pathToModel, "char3GramToIdxMap"));
 			ois = new ObjectInputStream(fis);
 			Map<String, Integer> char3GramToIdxMap_0 = (HashMap<String, Integer>) ois.readObject();
 			((NGramIterator)fullSetIterator).char3GramToIdxMap = char3GramToIdxMap_0;
@@ -130,6 +120,8 @@ public class BILSTMC3GClassifier extends BaseNNClassifier {
 		double adaGradCore = 0.04;
 		double adaGradDense = 0.01;
 		double adaGradGraves = 0.008;
+
+		saveParams();
 
 		// seed for reproducibility
 		final int seed = 12345;
@@ -182,14 +174,12 @@ public class BILSTMC3GClassifier extends BaseNNClassifier {
 		return "BILSTMC3G_MBL";
 	}
 
-	protected void saveModel(int epoch) {
-		super.saveModel(epoch);
-
+	protected void saveParams() {
 		File root = getModelDirectory(patientExamples);
 
 		try {
 			// writing our character n-grams
-			FileOutputStream fos = new FileOutputStream(new File(root, "characterNGram_3_" + trainCounter));
+			FileOutputStream fos = new FileOutputStream(new File(root, "characterNGram_3"));
 			ObjectOutputStream oos = new ObjectOutputStream(fos);
 			oos.writeObject(((NGramIterator)fullSetIterator).characterNGram_3);
 			oos.flush();
@@ -197,7 +187,7 @@ public class BILSTMC3GClassifier extends BaseNNClassifier {
 			fos.close();
 
 			// writing our character n-grams
-			fos = new FileOutputStream(new File(root, "char3GramToIdxMap_" + trainCounter));
+			fos = new FileOutputStream(new File(root, "char3GramToIdxMap"));
 			oos = new ObjectOutputStream(fos);
 			oos.writeObject(((NGramIterator)fullSetIterator).char3GramToIdxMap);
 			oos.flush();

--- a/src/test/java/at/medunigraz/imi/bst/n2c2/nn/BILSTMC3GClassifierTest.java
+++ b/src/test/java/at/medunigraz/imi/bst/n2c2/nn/BILSTMC3GClassifierTest.java
@@ -1,6 +1,7 @@
 package at.medunigraz.imi.bst.n2c2.nn;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -14,13 +15,13 @@ import org.xml.sax.SAXException;
 import at.medunigraz.imi.bst.n2c2.dao.PatientDAO;
 import at.medunigraz.imi.bst.n2c2.model.Criterion;
 import at.medunigraz.imi.bst.n2c2.model.Patient;
-import at.medunigraz.imi.bst.n2c2.util.DatasetUtil;
 
 public class BILSTMC3GClassifierTest {
 
+	private static final File SAMPLE = new File(BILSTMC3GClassifierTest.class.getResource("/gold-standard/sample.xml").getPath());
+
 	@Test
 	public void predictSample() throws IOException, SAXException {
-		final File SAMPLE = new File(getClass().getResource("/gold-standard/sample.xml").getPath());
 		Patient p = new PatientDAO().fromXML(SAMPLE);
 
 		// For test purposes only, we train and test on the same single patient
@@ -31,6 +32,45 @@ public class BILSTMC3GClassifierTest {
 		nn.deleteModelDir(train);	// Delete any previously trained models, to ensure training is tested
 		nn.train(train);
 
+		assertSamplePatient(nn, p);
+	}
+
+	@Test
+	public void saveAndLoad() throws IOException, SAXException {
+		Patient p = new PatientDAO().fromXML(SAMPLE);
+
+		List<Patient> train = new ArrayList<>();
+		train.add(p);
+
+		// We first train on some examples...
+		BILSTMC3GClassifier trainClassifier = new BILSTMC3GClassifier();
+		trainClassifier.deleteModelDir(train);	// Delete any previously trained models, to ensure training is tested
+		trainClassifier.train(train);			// This should persist models
+		assertTrue(trainClassifier.isTrained(train));
+
+		// ... and then try to load the model on a new instance.
+		BILSTMC3GClassifier testClassifier = new BILSTMC3GClassifier();
+		assertTrue(testClassifier.isTrained(train));
+		// TODO use Mockito to call train() and ensure trainFullSetBMC is NOT called.
+		testClassifier.initializeNetworkFromFile(BaseNNClassifier.getModelPath(train));
+
+		// Check classifier attributes are properly initialized
+		assertEquals(trainClassifier.truncateLength, testClassifier.truncateLength);
+		assertEquals(trainClassifier.vectorSize, testClassifier.vectorSize);
+
+		// Check maps are properly initialized
+		NGramIterator trainIterator = (NGramIterator)trainClassifier.fullSetIterator;
+		NGramIterator testIterator = (NGramIterator)testClassifier.fullSetIterator;
+		assertEquals(trainIterator.characterNGram_3, testIterator.characterNGram_3);
+		assertEquals(trainIterator.char3GramToIdxMap, testIterator.char3GramToIdxMap);
+
+		// XXX maxSentences is not initialized, but is not needed for prediction
+		//assertEquals(trainIterator.maxSentences, testIterator.maxSentences);
+
+		assertSamplePatient(testClassifier, p);
+	}
+
+	private void assertSamplePatient(BILSTMC3GClassifier nn, Patient p) {
 		assertEquals(Eligibility.NOT_MET, nn.predict(p, Criterion.ABDOMINAL));
 		assertEquals(Eligibility.MET, nn.predict(p, Criterion.ADVANCED_CAD));
 		assertEquals(Eligibility.NOT_MET, nn.predict(p, Criterion.ALCOHOL_ABUSE));


### PR DESCRIPTION
Previous code would save a model only after converging, which was not the original intent. Move the `saveModel(epoch)` call to inner training loop. As a consequence, save in a properties file the epoch of the best model and use it when loading the network from file.

Also, as character trigram maps do not change per epoch, save them in a new `saveParams` method called only once.

Finally, remove the `trainCounter` variable, which seemed unused.

Add tests to ensure variables and prediction are working as expected.